### PR TITLE
Add dedicated phone number identification message type

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -3,6 +3,7 @@
 import {
   Message,
   TriggerWorkflowMessage,
+  PhoneNumberIdentifiedMessage,
   WorkflowUpdateMessage,
   WorkflowCompleteMessage,
   WorkflowErrorMessage,
@@ -65,6 +66,7 @@ async function handleWorkflow(): Promise<void> {
     if (TEST_MODE) {
       // Test mode: use static phone number, skip RingCentral steps
       phoneNumber = TEST_PHONE_NUMBER;
+      sendPhoneNumberIdentified(phoneNumber);
       sendWorkflowUpdate(`Test Mode: Using static number ${phoneNumber}. Searching FreshService...`);
     } else {
       // Normal mode: find RingCentral tab and extract calling number
@@ -113,6 +115,7 @@ async function extractCallingNumber(tabId: number): Promise<string> {
   }
 
   const phoneNumber = callingNumberResult.phoneNumber;
+  sendPhoneNumberIdentified(phoneNumber);
   sendWorkflowUpdate(`Phone number found: ${phoneNumber}. Searching FreshService...`);
   return phoneNumber;
 }
@@ -193,6 +196,16 @@ async function processSearchResults(
  */
 async function openRequesterProfileTab(requesterData: StoredRequester): Promise<void> {
   await TabManager.createTab(FRESHSERVICE_USER_PROFILE_URL(requesterData.requesterUserId), false);
+}
+
+/**
+ * Send phone number identified message to sidepanel
+ */
+function sendPhoneNumberIdentified(phoneNumber: string): void {
+  MessageService.sendToSidepanel<PhoneNumberIdentifiedMessage>({
+    type: 'PHONE_NUMBER_IDENTIFIED',
+    phoneNumber: phoneNumber,
+  });
 }
 
 /**

--- a/src/sidepanel/sidepanel.ts
+++ b/src/sidepanel/sidepanel.ts
@@ -1,9 +1,10 @@
-import { 
-  Message, 
+import {
+  Message,
   TriggerWorkflowMessage,
+  PhoneNumberIdentifiedMessage,
   WorkflowUpdateMessage,
   WorkflowCompleteMessage,
-  WorkflowErrorMessage 
+  WorkflowErrorMessage
 } from '../types';
 
 // UI elements
@@ -34,6 +35,9 @@ function init(): void {
  */
 function handleMessage(message: Message): void {
   switch (message.type) {
+    case 'PHONE_NUMBER_IDENTIFIED':
+      handlePhoneNumberIdentified(message);
+      break;
     case 'WORKFLOW_UPDATE':
       handleWorkflowUpdate(message);
       break;
@@ -47,17 +51,19 @@ function handleMessage(message: Message): void {
 }
 
 /**
+ * Handle phone number identified message
+ */
+function handlePhoneNumberIdentified(message: PhoneNumberIdentifiedMessage): void {
+  if (phoneNumberSpan) {
+    phoneNumberSpan.textContent = message.phoneNumber;
+  }
+}
+
+/**
  * Handle workflow update messages
  */
 function handleWorkflowUpdate(message: WorkflowUpdateMessage): void {
   if (!resultDiv) return;
-
-  // Extract and display phone number if present in message
-  // Matches both: "Phone number found: 1234567890." and "Test Mode: Using static number 1234567890."
-  const phoneMatch = message.message.match(/(?:Phone number found|Using static number): (\d+)\./);
-  if (phoneMatch && phoneNumberSpan) {
-    phoneNumberSpan.textContent = phoneMatch[1];
-  }
 
   resultDiv.innerHTML = `
     <div style="color: #666;">${message.message}</div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,11 @@
 // Message types for Chrome extension messaging
-export type MessageType = 
+export type MessageType =
   | 'GET_CALLING_NUMBER'
   | 'CALLING_NUMBER_RESULT'
   | 'SCRAPE_SEARCH_RESULTS'
   | 'SEARCH_RESULTS_RESULT'
   | 'TRIGGER_WORKFLOW'
+  | 'PHONE_NUMBER_IDENTIFIED'
   | 'WORKFLOW_UPDATE'
   | 'WORKFLOW_COMPLETE'
   | 'WORKFLOW_ERROR';
@@ -39,6 +40,11 @@ export interface TriggerWorkflowMessage extends BaseMessage {
   type: 'TRIGGER_WORKFLOW';
 }
 
+export interface PhoneNumberIdentifiedMessage extends BaseMessage {
+  type: 'PHONE_NUMBER_IDENTIFIED';
+  phoneNumber: string;
+}
+
 export interface WorkflowUpdateMessage extends BaseMessage {
   type: 'WORKFLOW_UPDATE';
   status: string;
@@ -56,12 +62,13 @@ export interface WorkflowErrorMessage extends BaseMessage {
   details?: string;
 }
 
-export type Message = 
+export type Message =
   | GetCallingNumberMessage
   | CallingNumberResultMessage
   | ScrapeSearchResultsMessage
   | SearchResultsResultMessage
   | TriggerWorkflowMessage
+  | PhoneNumberIdentifiedMessage
   | WorkflowUpdateMessage
   | WorkflowCompleteMessage
   | WorkflowErrorMessage;


### PR DESCRIPTION
## Summary
Refactored phone number handling to use a dedicated message type (`PHONE_NUMBER_IDENTIFIED`) instead of parsing phone numbers from workflow update messages. This improves separation of concerns and makes the messaging protocol more explicit.

## Key Changes
- **New message type**: Added `PhoneNumberIdentifiedMessage` to the types system with a dedicated `PHONE_NUMBER_IDENTIFIED` message type
- **Background script**: Modified to send phone number identification messages immediately when a phone number is extracted (both in test mode and normal RingCentral extraction flow)
- **Sidepanel UI**: 
  - Added handler for the new `PHONE_NUMBER_IDENTIFIED` message type
  - Removed regex-based phone number extraction from `handleWorkflowUpdate()` 
  - Phone number is now displayed via the dedicated handler instead of being parsed from workflow messages
- **Code cleanup**: Fixed trailing whitespace in import statements across modified files

## Implementation Details
- The `sendPhoneNumberIdentified()` function is called in two places:
  1. In test mode when using the static test phone number
  2. After extracting the calling number from the RingCentral tab
- This ensures the UI always receives explicit phone number identification before workflow updates, providing a cleaner separation between phone number identification and workflow status updates

https://claude.ai/code/session_01NNWzwVZqUy5zFfQ8X1WkJS