### PR TITLE
Add new ticket autofill with Standard Ticket template

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -25,6 +25,7 @@ SD-Bot is a Chrome browser extension that automates service desk workflows by in
 - Extracting caller phone numbers from active calls
 - Searching for requesters in FreshService
 - Opening relevant tabs when a unique requester is found
+- Applying the Standard Ticket template to the new ticket and pre-filling the description with caller details
 - Providing real-time status updates via a side panel
 
 ### Technology Stack
@@ -90,7 +91,8 @@ sd-bot/
 │   │   └── ringcentral.ts          # RingCentral content script
 │   ├── scrapers/
 │   │   ├── freshservice-scraper.ts # FreshService DOM scraping
-│   │   └── ringcentral-scraper.ts  # RingCentral DOM scraping
+│   │   ├── ringcentral-scraper.ts  # RingCentral DOM scraping
+│   │   └── ticket-form-filler.ts   # New ticket template selection + description autofill
 │   ├── services/
 │   │   ├── message-service.ts      # Chrome messaging abstraction
 │   │   ├── storage-service.ts      # Chrome storage abstraction
@@ -103,6 +105,7 @@ sd-bot/
 │   ├── utils/
 │   │   ├── config.ts               # Configuration constants
 │   │   ├── content-message-handler.ts # Generic message handler
+│   │   ├── dom-utils.ts            # DOM polling waits + synthetic mouse events
 │   │   └── error-handler.ts        # Error formatting utilities
 │   └── images/
 │       └── icon-128.png            # Extension icon
@@ -119,7 +122,7 @@ sd-bot/
 #### Background Service Worker ([src/background/background.ts](src/background/background.ts))
 - **Main orchestrator** of extension workflow
 - Listens for extension icon clicks to open side panel
-- Manages 5-step workflow execution
+- Manages 6-step workflow execution
 - Coordinates communication between content scripts
 - Sends status updates to side panel
 - Handles errors and recovery
@@ -141,6 +144,13 @@ sd-bot/
   - Identifies requester section
   - Handles 3 scenarios: single match (success), no match, multiple matches
   - Returns structured RequesterData
+
+- **Ticket Form Filler** ([src/scrapers/ticket-form-filler.ts](src/scrapers/ticket-form-filler.ts)):
+  - Runs in the new ticket tab (Ember SPA — waits for elements via polling)
+  - Opens the "Select template" dropdown (ember-power-select) and chooses "Standard Ticket"
+  - Waits for the template to populate the Froala description editor
+  - Rewrites the description to keep only the TM Name / Ph# / Laptop# lines, filling in requester name and phone number
+  - Idempotent: skips template selection if the template content is already present
 
 #### Services
 - **TabManager** ([src/services/tab-manager.ts](src/services/tab-manager.ts)):
@@ -346,9 +356,11 @@ const phoneNumber = result.phoneNumber;
 
 ## Core Workflow
 
-### 5-Step Automation Workflow
+### 6-Step Automation Workflow
 
-The workflow executes when the user clicks the extension icon:
+The workflow executes when the user clicks the extension icon. The new ticket
+tab is opened right after the calling number is identified (before the search),
+and its tab ID is kept so the autofill step can message it later:
 
 **Step 1: Find RingCentral MAX Tab**
 ```typescript
@@ -406,10 +418,32 @@ async function processSearchResults(
 }
 ```
 
-**Step 5: Open Requester Tabs**
+**Step 5: Autofill New Ticket**
 ```typescript
-async function openRequesterTabs(requesterData: StoredRequester): Promise<void> {
-  await TabManager.createTab(FRESHSERVICE_NEW_TICKET_URL, false);
+// Runs even when the requester was NOT uniquely identified —
+// TM Name is simply left blank in that case
+const autofillError = await autofillNewTicket(
+  ticketTab.id!,
+  requesterData?.requesterName ?? '',
+  phoneNumber
+);
+```
+The background sends an `AUTOFILL_TICKET` message to the FreshService content
+script in the ticket tab (with retries while the content script loads). The
+content script applies the Standard Ticket template and rewrites the
+description to:
+
+```
+TM Name: <requester name>
+Ph#: <phone number>
+Laptop#:
+```
+
+Autofill failures are reported to the side panel but do not abort the workflow.
+
+**Step 6: Open Requester Profile Tab**
+```typescript
+async function openRequesterProfileTab(requesterData: StoredRequester): Promise<void> {
   await TabManager.createTab(
     FRESHSERVICE_USER_PROFILE_URL(requesterData.requesterUserId),
     false
@@ -440,7 +474,11 @@ User Click → Background Service Worker
                     ↓
          Store requester data in Chrome Storage
                     ↓
-         Open new ticket tab + user profile tab
+         Send AUTOFILL_TICKET message → FreshService Content Script (ticket tab)
+                    ↓                              ↓
+         Wait for response          Apply template, rewrite description
+                    ↓
+         Open user profile tab
                     ↓
          Send WORKFLOW_COMPLETE message → Side Panel
 ```
@@ -1271,9 +1309,14 @@ const element =
 
 ## Version History
 
-**Current Version**: 1.5.2
+**Current Version**: 1.6.0
 
 **Recent Changes**:
+- Added new ticket autofill: applies the "Standard Ticket" template on the new ticket tab and rewrites the description to TM Name / Ph# / Laptop# lines pre-filled with requester name and phone number (blank TM Name when no unique requester match)
+- Added `AUTOFILL_TICKET` / `AUTOFILL_TICKET_RESULT` message types and `MessageService.autofillTicket`
+- Added `src/scrapers/ticket-form-filler.ts` and `src/utils/dom-utils.ts` (DOM polling waits, synthetic mouse event sequences)
+- `createContentMessageHandler` now supports async handlers
+- Reference DOM captures of the new ticket form live in `dom-captures/`
 - Moved `sendPhoneNumberIdentified` to `handleWorkflow` as explicit first step; `extractCallingNumber` is now a pure extraction function
 - Reset requester-info spans in `init()` to prevent stale data on panel reopen
 - Refactored message sending to use centralized helper

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SD Bot",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Bot for automating various service desk functions",
   "icons": {
     "128": "dist/images/icon-128.png"

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -10,6 +10,7 @@ import {
   StoredRequester,
   CallingNumberResultMessage,
   SearchResultsResultMessage,
+  AutofillTicketResultMessage,
   isSuccessfulCallingNumberResult,
   isSuccessfulSingleMatchResult,
   isMultipleRequestersResult
@@ -17,11 +18,12 @@ import {
 import { TabManager } from '../services/tab-manager';
 import { StorageService } from '../services/storage-service';
 import { MessageService } from '../services/message-service';
-import { 
-  RINGCENTRAL_PATTERN, 
-  FRESHSERVICE_SEARCH_URL, 
+import {
+  RINGCENTRAL_PATTERN,
+  FRESHSERVICE_SEARCH_URL,
   FRESHSERVICE_NEW_TICKET_URL,
   FRESHSERVICE_USER_PROFILE_URL,
+  AUTOFILL_RETRY,
   TEST_MODE,
   TEST_PHONE_NUMBER
 } from '../utils/config';
@@ -76,12 +78,41 @@ async function handleWorkflow(): Promise<void> {
       sendWorkflowUpdate(`Searching FreshService for ${phoneNumber}...`);
     }
 
-    // Always open new ticket tab first
-    await TabManager.createTab(FRESHSERVICE_NEW_TICKET_URL, false);
+    // Always open new ticket tab first; keep a handle on it for autofill
+    const ticketTab = await TabManager.createTab(FRESHSERVICE_NEW_TICKET_URL, false);
 
     const searchTab = await searchFreshService(phoneNumber);
-    const requesterData = await processSearchResults(searchTab.id!, phoneNumber);
+
+    // Identify the requester, but prep the new ticket even when identification fails
+    let requesterData: StoredRequester | undefined;
+    let searchError: unknown;
+    try {
+      requesterData = await processSearchResults(searchTab.id!, phoneNumber);
+    } catch (error) {
+      searchError = error;
+    }
+
+    // TM Name is left blank when no unique requester was found
+    const autofillError = await autofillNewTicket(
+      ticketTab.id!,
+      requesterData?.requesterName ?? '',
+      phoneNumber
+    );
+
+    if (searchError !== undefined || !requesterData) {
+      throw searchError;
+    }
+
     await openRequesterProfileTab(requesterData);
+
+    if (autofillError) {
+      sendWorkflowError(
+        'Ticket autofill failed',
+        `${autofillError} Fill the ticket description manually.`
+      );
+      return;
+    }
+
     sendWorkflowComplete(requesterData);
   } catch (error) {
     const errorMessage = formatErrorWithStack(error, true);
@@ -190,7 +221,56 @@ async function processSearchResults(
 }
 
 /**
- * Step 5: Open user profile tab for identified requester
+ * Step 5: Autofill the new ticket with the Standard Ticket template and caller details
+ * Failures are reported without aborting the workflow — the opened tabs are still useful
+ * @param ticketTabId - The tab ID of the new ticket tab opened at workflow start
+ * @param requesterName - Requester name ('' when not uniquely identified)
+ * @param phoneNumber - The caller's phone number
+ * @returns An error description on failure, or null on success
+ */
+async function autofillNewTicket(
+  ticketTabId: number,
+  requesterName: string,
+  phoneNumber: string
+): Promise<string | null> {
+  sendWorkflowUpdate('Prepping new ticket with Standard Ticket template...');
+  try {
+    const result = await sendAutofillWithRetry(ticketTabId, requesterName, phoneNumber);
+    if (!result.success) {
+      return result.error || 'Ticket autofill failed for an unknown reason.';
+    }
+    sendWorkflowUpdate('New ticket prepped with caller details.');
+    return null;
+  } catch (error) {
+    return formatErrorWithStack(error, true);
+  }
+}
+
+/**
+ * Sends the autofill message, retrying while the ticket tab's content script
+ * may still be loading (the tab was opened without waiting for it)
+ */
+async function sendAutofillWithRetry(
+  tabId: number,
+  requesterName: string,
+  phoneNumber: string
+): Promise<AutofillTicketResultMessage> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < AUTOFILL_RETRY.attempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, AUTOFILL_RETRY.delayMs));
+    }
+    try {
+      return await MessageService.autofillTicket(tabId, requesterName, phoneNumber);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Step 6: Open user profile tab for identified requester
  * @param requesterData - The requester data containing user ID
  */
 async function openRequesterProfileTab(requesterData: StoredRequester): Promise<void> {

--- a/src/content/freshservice.ts
+++ b/src/content/freshservice.ts
@@ -1,5 +1,11 @@
-import { ScrapeSearchResultsMessage, SearchResultsResultMessage } from '../types';
+import {
+  ScrapeSearchResultsMessage,
+  SearchResultsResultMessage,
+  AutofillTicketMessage,
+  AutofillTicketResultMessage
+} from '../types';
 import { scrapeSearchResults } from '../scrapers/freshservice-scraper';
+import { autofillNewTicket } from '../scrapers/ticket-form-filler';
 import { createContentMessageHandler } from '../utils/content-message-handler';
 
 // Listen for messages from background script
@@ -17,6 +23,26 @@ chrome.runtime.onMessage.addListener(
     },
     (errorMessage) => ({
       type: 'SEARCH_RESULTS_RESULT',
+      success: false,
+      error: errorMessage,
+    })
+  )
+);
+
+// Autofill the new ticket form when requested by the background workflow
+chrome.runtime.onMessage.addListener(
+  createContentMessageHandler<AutofillTicketMessage, AutofillTicketResultMessage>(
+    'AUTOFILL_TICKET',
+    async (message) => {
+      const result = await autofillNewTicket(message.requesterName, message.phoneNumber);
+      return {
+        type: 'AUTOFILL_TICKET_RESULT',
+        success: result.success,
+        error: result.error,
+      };
+    },
+    (errorMessage) => ({
+      type: 'AUTOFILL_TICKET_RESULT',
       success: false,
       error: errorMessage,
     })

--- a/src/scrapers/ticket-form-filler.ts
+++ b/src/scrapers/ticket-form-filler.ts
@@ -1,0 +1,177 @@
+import { TicketAutofillResult } from '../types';
+import { FRESHSERVICE_TICKET_SELECTORS, TICKET_TEMPLATE, TIMEOUTS } from '../utils/config';
+import { waitFor, dispatchMouseSequence } from '../utils/dom-utils';
+import { formatErrorWithStack } from '../utils/error-handler';
+
+/**
+ * Removes Froala's zero-width marker characters and trims whitespace
+ */
+function cleanText(text: string | null | undefined): string {
+  return (text ?? '').replace(/\u200B/g, '').trim();
+}
+
+function getDescriptionEditor(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(FRESHSERVICE_TICKET_SELECTORS.descriptionEditor);
+}
+
+/**
+ * Returns the description editor once the template content has populated it,
+ * or null while it is still empty
+ */
+function getPopulatedEditor(): HTMLElement | null {
+  const editor = getDescriptionEditor();
+  if (editor && cleanText(editor.textContent).includes(TICKET_TEMPLATE.appliedMarker)) {
+    return editor;
+  }
+  return null;
+}
+
+/**
+ * Finds the dropdown option matching the configured template name
+ * Options render only while the dropdown is open
+ */
+function findTemplateOption(): HTMLElement | null {
+  const options = document.querySelectorAll<HTMLElement>(
+    FRESHSERVICE_TICKET_SELECTORS.templateOption
+  );
+  for (const option of options) {
+    if (cleanText(option.textContent) === TICKET_TEMPLATE.name) {
+      return option;
+    }
+  }
+  return null;
+}
+
+/**
+ * Opens the template dropdown, selects the configured template, and waits
+ * for the description editor to be populated with the template content
+ * @returns The populated description editor element
+ */
+async function applyTemplate(): Promise<HTMLElement> {
+  // Template may already be applied (e.g. workflow re-run against the same tab)
+  const alreadyPopulated = getPopulatedEditor();
+  if (alreadyPopulated) {
+    return alreadyPopulated;
+  }
+
+  const trigger = await waitFor(
+    () => document.querySelector<HTMLElement>(FRESHSERVICE_TICKET_SELECTORS.templateTrigger),
+    TIMEOUTS.ticketFormLoad,
+    'template dropdown trigger'
+  );
+
+  dispatchMouseSequence(trigger);
+
+  let option: HTMLElement;
+  try {
+    option = await waitFor(
+      findTemplateOption,
+      TIMEOUTS.dropdownOpen,
+      `"${TICKET_TEMPLATE.name}" option in template dropdown`
+    );
+  } catch {
+    // Fallback: some power-select configurations toggle from the inline search
+    // input inside the trigger rather than the trigger itself
+    const searchInput = trigger.querySelector<HTMLElement>(
+      FRESHSERVICE_TICKET_SELECTORS.templateSearchInput
+    );
+    if (searchInput) {
+      searchInput.focus();
+      dispatchMouseSequence(searchInput);
+    }
+    option = await waitFor(
+      findTemplateOption,
+      TIMEOUTS.templateApply,
+      `"${TICKET_TEMPLATE.name}" option in template dropdown (after retry)`
+    );
+  }
+
+  dispatchMouseSequence(option);
+
+  return waitFor(
+    getPopulatedEditor,
+    TIMEOUTS.templateApply,
+    'template content in description editor'
+  );
+}
+
+/**
+ * Builds a template line (<p><u><b>Label</b></u>&nbsp;</p>) matching the
+ * template's styling, for when a label paragraph is missing from the template
+ */
+function createTemplateLine(label: string): HTMLParagraphElement {
+  const paragraph = document.createElement('p');
+  const underline = document.createElement('u');
+  const bold = document.createElement('b');
+  bold.textContent = label;
+  underline.appendChild(bold);
+  paragraph.appendChild(underline);
+  paragraph.appendChild(document.createTextNode('\u00A0'));
+  return paragraph;
+}
+
+/**
+ * Replaces the populated template content with only the keep-label lines,
+ * appending the provided value after each label
+ */
+function rewriteDescription(editor: HTMLElement, values: Readonly<Record<string, string>>): void {
+  const paragraphs = Array.from(editor.querySelectorAll('p'));
+  const lines = document.createDocumentFragment();
+
+  for (const label of TICKET_TEMPLATE.keepLabels) {
+    // Reuse the template's own paragraph to preserve its styling; synthesize a
+    // matching line if the template text changed and the label is missing
+    const paragraph =
+      paragraphs.find((p) => cleanText(p.textContent).startsWith(label)) ??
+      createTemplateLine(label);
+
+    for (const marker of paragraph.querySelectorAll(FRESHSERVICE_TICKET_SELECTORS.editorMarker)) {
+      marker.remove();
+    }
+
+    const value = values[label];
+    if (value) {
+      paragraph.appendChild(document.createTextNode(value));
+    }
+
+    lines.appendChild(paragraph);
+  }
+
+  editor.innerHTML = '';
+  editor.appendChild(lines);
+
+  // Notify Froala/Ember that the content changed so the form model picks it up
+  editor.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true }));
+}
+
+/**
+ * Applies the Standard Ticket template to the new ticket form and rewrites the
+ * description down to the keep lines with caller details filled in:
+ *
+ *   TM Name: <requesterName>
+ *   Ph#: <phoneNumber>
+ *   Laptop#:
+ *
+ * @param requesterName - Requester name; empty string leaves TM Name blank
+ *   (used when no unique requester was identified)
+ * @param phoneNumber - Caller phone number in raw format
+ */
+export async function autofillNewTicket(
+  requesterName: string,
+  phoneNumber: string
+): Promise<TicketAutofillResult> {
+  try {
+    const editor = await applyTemplate();
+    rewriteDescription(editor, {
+      [TICKET_TEMPLATE.tmNameLabel]: requesterName,
+      [TICKET_TEMPLATE.phoneLabel]: phoneNumber,
+      [TICKET_TEMPLATE.laptopLabel]: '',
+    });
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error autofilling new ticket: ${formatErrorWithStack(error, true)}`,
+    };
+  }
+}

--- a/src/services/message-service.ts
+++ b/src/services/message-service.ts
@@ -1,9 +1,11 @@
-import { 
-  Message, 
-  CallingNumberResultMessage, 
+import {
+  Message,
+  CallingNumberResultMessage,
   SearchResultsResultMessage,
   GetCallingNumberMessage,
-  ScrapeSearchResultsMessage
+  ScrapeSearchResultsMessage,
+  AutofillTicketMessage,
+  AutofillTicketResultMessage
 } from '../types';
 
 /**
@@ -99,6 +101,27 @@ export class MessageService {
       type: 'SCRAPE_SEARCH_RESULTS',
     };
     return this.sendToTab<SearchResultsResultMessage>(tabId, request);
+  }
+
+  /**
+   * Request new ticket autofill from the FreshService content script
+   * @param tabId - The ID of the tab containing the new ticket form
+   * @param requesterName - Requester name for the TM Name line ('' leaves it blank)
+   * @param phoneNumber - Caller phone number for the Ph# line
+   * @returns Promise that resolves with the autofill result
+   * @throws Error if the message cannot be sent or if no response is received
+   */
+  static async autofillTicket(
+    tabId: number,
+    requesterName: string,
+    phoneNumber: string
+  ): Promise<AutofillTicketResultMessage> {
+    const request: AutofillTicketMessage = {
+      type: 'AUTOFILL_TICKET',
+      requesterName,
+      phoneNumber,
+    };
+    return this.sendToTab<AutofillTicketResultMessage>(tabId, request);
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,8 @@ export type MessageType =
   | 'CALLING_NUMBER_RESULT'
   | 'SCRAPE_SEARCH_RESULTS'
   | 'SEARCH_RESULTS_RESULT'
+  | 'AUTOFILL_TICKET'
+  | 'AUTOFILL_TICKET_RESULT'
   | 'TRIGGER_WORKFLOW'
   | 'PHONE_NUMBER_IDENTIFIED'
   | 'WORKFLOW_UPDATE'
@@ -33,6 +35,20 @@ export interface SearchResultsResultMessage extends BaseMessage {
   type: 'SEARCH_RESULTS_RESULT';
   success: boolean;
   data?: RequesterData;
+  error?: string;
+}
+
+export interface AutofillTicketMessage extends BaseMessage {
+  type: 'AUTOFILL_TICKET';
+  /** Requester name for the TM Name line; empty string leaves it blank */
+  requesterName: string;
+  /** Caller phone number in raw format for the Ph# line */
+  phoneNumber: string;
+}
+
+export interface AutofillTicketResultMessage extends BaseMessage {
+  type: 'AUTOFILL_TICKET_RESULT';
+  success: boolean;
   error?: string;
 }
 
@@ -67,6 +83,8 @@ export type Message =
   | CallingNumberResultMessage
   | ScrapeSearchResultsMessage
   | SearchResultsResultMessage
+  | AutofillTicketMessage
+  | AutofillTicketResultMessage
   | TriggerWorkflowMessage
   | PhoneNumberIdentifiedMessage
   | WorkflowUpdateMessage
@@ -99,6 +117,11 @@ export interface RequesterData {
 export interface ScrapeResult<T> {
   success: boolean;
   data?: T;
+  error?: string;
+}
+
+export interface TicketAutofillResult {
+  success: boolean;
   error?: string;
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -32,10 +32,45 @@ export const FRESHSERVICE_SELECTORS = {
   ticketItem: 'li:not(.heading)',
 } as const;
 
+// DOM selectors for the FreshService new ticket form
+// IDs on the form are Ember-generated (ember13, ember15, ...) and change between
+// page loads, so selectors rely on aria-labels and stable component classes
+export const FRESHSERVICE_TICKET_SELECTORS = {
+  templateTrigger: '.ember-power-select-trigger[aria-label="Select template"]',
+  templateSearchInput: 'input.ember-power-select-search-input',
+  templateOption: 'li.ember-power-select-option',
+  descriptionEditor: '.fr-element.fr-view[contenteditable="true"]',
+  // Froala's hidden cursor-position markers, stripped from kept template lines
+  editorMarker: 'span.fr-marker',
+} as const;
+
+// Ticket template configuration
+export const TICKET_TEMPLATE = {
+  name: 'Standard Ticket',
+  tmNameLabel: 'TM Name:',
+  phoneLabel: 'Ph#:',
+  laptopLabel: 'Laptop#:',
+  // Line labels to keep from the template, in output order; every other line is deleted
+  keepLabels: ['TM Name:', 'Ph#:', 'Laptop#:'],
+  // Text whose presence signals the template has populated the description editor
+  appliedMarker: 'TM Name:',
+} as const;
+
 // Timeout constants (in milliseconds)
 export const TIMEOUTS = {
   tabLoad: 10000, // 10 seconds for tab to load
   contentRender: 500, // 500ms additional delay for content rendering
+  ticketFormLoad: 15000, // new ticket form (Ember SPA) render wait
+  dropdownOpen: 3000, // first wait for options after opening the template dropdown
+  templateApply: 10000, // wait for template content to populate the editor
+  domPoll: 200, // polling interval for DOM waits
+} as const;
+
+// Retry configuration for messaging the new ticket tab
+// (its content script may not be injected yet while the tab is still loading)
+export const AUTOFILL_RETRY = {
+  attempts: 5,
+  delayMs: 1000,
 } as const;
 
 // Storage keys

--- a/src/utils/content-message-handler.ts
+++ b/src/utils/content-message-handler.ts
@@ -3,9 +3,11 @@ import { Message } from '../types';
 /**
  * Generic message handler factory for content scripts
  * Creates a standardized message listener that handles errors consistently
- * 
+ *
  * @param messageType - The message type to listen for
- * @param handler - Function that processes the message and returns a response
+ * @param handler - Function that processes the message and returns a response,
+ *   either synchronously or as a Promise (the message channel is kept open
+ *   until an async handler resolves)
  * @param createErrorResponse - Function that creates an error response with the given error message
  * @returns A message listener function compatible with chrome.runtime.onMessage
  * 
@@ -34,7 +36,7 @@ import { Message } from '../types';
  */
 export function createContentMessageHandler<TRequest extends Message, TResponse extends Message>(
   messageType: TRequest['type'],
-  handler: (message: TRequest) => TResponse,
+  handler: (message: TRequest) => TResponse | Promise<TResponse>,
   createErrorResponse: (errorMessage: string) => TResponse
 ): (
   message: Message,
@@ -49,7 +51,16 @@ export function createContentMessageHandler<TRequest extends Message, TResponse 
     if (message.type === messageType) {
       try {
         const response = handler(message as TRequest);
-        sendResponse(response);
+        if (response instanceof Promise) {
+          response
+            .then((resolved) => sendResponse(resolved))
+            .catch((error: unknown) => {
+              const errorMessage = error instanceof Error ? error.message : String(error);
+              sendResponse(createErrorResponse(errorMessage));
+            });
+        } else {
+          sendResponse(response);
+        }
         return true; // Indicates we will send a response asynchronously
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -58,7 +69,7 @@ export function createContentMessageHandler<TRequest extends Message, TResponse 
         return true;
       }
     }
-    
+
     return false;
   };
 }

--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * DOM utilities for content scripts: waiting on asynchronously rendered
+ * elements (SPA pages) and dispatching synthetic mouse events
+ */
+
+import { TIMEOUTS } from './config';
+
+/**
+ * Polls until check returns a non-null value or the timeout elapses
+ * @param check - Function returning the awaited value (null/undefined = keep waiting)
+ * @param timeoutMs - Maximum time to wait
+ * @param description - Human-readable description used in the timeout error
+ * @param intervalMs - Poll interval (default: TIMEOUTS.domPoll)
+ * @returns The first non-null value returned by check
+ * @throws Error if the timeout elapses before check returns a value
+ */
+export async function waitFor<T>(
+  check: () => T | null | undefined,
+  timeoutMs: number,
+  description: string,
+  intervalMs: number = TIMEOUTS.domPoll
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const value = check();
+    if (value !== null && value !== undefined) {
+      return value;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for ${description}`);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+/**
+ * Dispatches a mousedown/mouseup/click sequence on an element
+ *
+ * Covers UI libraries that act on any one of the three: ember-basic-dropdown
+ * toggles on mousedown or click depending on version/configuration, and
+ * ember-power-select chooses options on mouseup
+ */
+export function dispatchMouseSequence(element: Element): void {
+  for (const type of ['mousedown', 'mouseup', 'click'] as const) {
+    element.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, cancelable: true, view: window })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds automatic ticket form population to the SD-Bot workflow. When a new FreshService ticket tab is opened, the extension now applies the "Standard Ticket" template and pre-fills the description with caller details (requester name and phone number).

## Key Changes

- **New ticket form autofill** (`src/scrapers/ticket-form-filler.ts`):
  - Opens the template dropdown and selects "Standard Ticket"
  - Waits for the Froala editor to populate with template content
  - Rewrites the description to keep only TM Name / Ph# / Laptop# lines
  - Pre-fills TM Name and Ph# with requester details (TM Name left blank if no unique match)
  - Idempotent: skips template selection if already applied
  - Includes fallback logic for different ember-power-select configurations

- **DOM utilities** (`src/utils/dom-utils.ts`):
  - `waitFor()`: Polls for asynchronously rendered elements with configurable timeout
  - `dispatchMouseSequence()`: Sends mousedown/mouseup/click events to handle various UI library behaviors

- **Message infrastructure**:
  - Added `AUTOFILL_TICKET` and `AUTOFILL_TICKET_RESULT` message types
  - `MessageService.autofillTicket()` sends autofill requests to the ticket tab
  - Updated `createContentMessageHandler` to support async handlers with proper Promise handling

- **Workflow integration** (`src/background/background.ts`):
  - New Step 5: Autofill the ticket tab (runs even when requester identification fails)
  - Implements retry logic (`AUTOFILL_RETRY`) to handle content script injection delays
  - Autofill failures are reported but don't abort the workflow
  - Requester profile tab opening moved to Step 6

- **Configuration** (`src/utils/config.ts`):
  - Added `FRESHSERVICE_TICKET_SELECTORS` for new ticket form elements
  - Added `TICKET_TEMPLATE` configuration (template name, labels, markers)
  - Added timeout constants for form loading and template application
  - Added retry configuration for messaging the ticket tab

- **Type definitions** (`src/types/index.ts`):
  - Added `AutofillTicketMessage` and `AutofillTicketResultMessage` types
  - Added `TicketAutofillResult` interface

- **Content script** (`src/content/freshservice.ts`):
  - Registered message handler for `AUTOFILL_TICKET` requests

- **Documentation** (`claude.md`):
  - Updated workflow from 5 steps to 6 steps
  - Added ticket form filler architecture details
  - Updated version to 1.6.0

## Implementation Details

- Uses DOM polling with configurable timeouts to handle Ember SPA rendering delays
- Synthetic mouse events cover multiple UI library implementations (ember-basic-dropdown, ember-power-select)
- Template application is idempotent by checking for the applied marker text
- Froala editor changes are notified via `InputEvent` to ensure form model updates
- Retry mechanism handles cases where the content script hasn't injected yet when the tab opens

https://claude.ai/code/session_01AZJKckVuk3YLaehdCSd866