### PR TITLE
Fix autofill and number extraction failing in hidden tabs/windows

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -360,7 +360,16 @@ const phoneNumber = result.phoneNumber;
 
 The workflow executes when the user clicks the extension icon. The new ticket
 tab is opened right after the calling number is identified (before the search),
-and its tab ID is kept so the autofill step can message it later:
+and its tab ID is kept so the autofill step can message it later.
+
+Two tabs are deliberately brought to the foreground during the workflow,
+because Chrome deprioritizes hidden tabs/windows (requestAnimationFrame never
+fires, timers are throttled), which can prevent SPA pages from rendering:
+
+- The **MAX tab** is activated (tab + window focus) before extracting the
+  calling number — the MAX window is often buried when a call comes in
+- The **new ticket tab** is activated before autofill so the Ember form
+  actually renders; it is also where the tech works next
 
 **Step 1: Find RingCentral MAX Tab**
 ```typescript
@@ -1309,9 +1318,14 @@ const element =
 
 ## Version History
 
-**Current Version**: 1.6.0
+**Current Version**: 1.6.1
 
-**Recent Changes**:
+**Recent Changes (1.6.1)**:
+- MAX tab is now activated (tab + window focus) before number extraction, with retries while the call UI renders — fixes extraction failing when the MAX window is buried behind others
+- New ticket tab is activated and awaited (`TabManager.activateTab` / `waitForTabComplete`) before the autofill message is sent — fixes autofill stalling in hidden background tabs
+- Ticket form filler logs each stage to the ticket tab's console with a `[SD-Bot]` prefix for field debugging
+
+**Recent Changes (1.6.0)**:
 - Added new ticket autofill: applies the "Standard Ticket" template on the new ticket tab and rewrites the description to TM Name / Ph# / Laptop# lines pre-filled with requester name and phone number (blank TM Name when no unique requester match)
 - Added `AUTOFILL_TICKET` / `AUTOFILL_TICKET_RESULT` message types and `MessageService.autofillTicket`
 - Added `src/scrapers/ticket-form-filler.ts` and `src/utils/dom-utils.ts` (DOM polling waits, synthetic mouse event sequences)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SD Bot",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Bot for automating various service desk functions",
   "icons": {
     "128": "dist/images/icon-128.png"

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -24,6 +24,7 @@ import {
   FRESHSERVICE_NEW_TICKET_URL,
   FRESHSERVICE_USER_PROFILE_URL,
   AUTOFILL_RETRY,
+  CALLING_NUMBER_RETRY,
   TEST_MODE,
   TEST_PHONE_NUMBER
 } from '../utils/config';
@@ -121,33 +122,48 @@ async function handleWorkflow(): Promise<void> {
 }
 
 /**
- * Step 1: Find RingCentral MAX tab
+ * Step 1: Find RingCentral MAX tab and bring it to the front
+ * The MAX window is often buried behind others when a call comes in, and
+ * Chrome deprioritizes hidden windows, so the call UI may not render or
+ * update until the window is visible again
  * @returns The RingCentral MAX tab
  * @throws Error if tab is not found
  */
 async function findRingCentralTab(): Promise<chrome.tabs.Tab> {
   sendWorkflowUpdate('Searching for MAX window...');
   const maxTab = await TabManager.findTabByUrl(RINGCENTRAL_PATTERN);
+  await TabManager.activateTab(maxTab.id!);
   sendWorkflowUpdate('Found MAX window. Checking for call data...');
   return maxTab;
 }
 
 /**
  * Step 2: Extract calling number from RingCentral content script
+ * Retries briefly: the call UI may need a moment to render after the MAX
+ * window is brought forward
  * @param tabId - The tab ID of the RingCentral MAX tab
  * @returns The extracted phone number
  * @throws Error if calling number cannot be extracted
  */
 async function extractCallingNumber(tabId: number): Promise<string> {
-  const callingNumberResult = await MessageService.getCallingNumber(tabId);
+  let lastError: string | undefined;
 
-  if (!isSuccessfulCallingNumberResult(callingNumberResult)) {
-    throw new Error(
-      callingNumberResult.error || 'No active call detected or calling number not available'
-    );
+  for (let attempt = 0; attempt < CALLING_NUMBER_RETRY.attempts; attempt++) {
+    if (attempt > 0) {
+      await delay(CALLING_NUMBER_RETRY.delayMs);
+    }
+    try {
+      const callingNumberResult = await MessageService.getCallingNumber(tabId);
+      if (isSuccessfulCallingNumberResult(callingNumberResult)) {
+        return callingNumberResult.phoneNumber;
+      }
+      lastError = callingNumberResult.error;
+    } catch (error) {
+      lastError = formatErrorWithStack(error, true);
+    }
   }
 
-  return callingNumberResult.phoneNumber;
+  throw new Error(lastError || 'No active call detected or calling number not available');
 }
 
 /**
@@ -235,13 +251,20 @@ async function autofillNewTicket(
 ): Promise<string | null> {
   sendWorkflowUpdate('Prepping new ticket with Standard Ticket template...');
   try {
+    // Foreground the ticket tab first: hidden tabs may never finish rendering
+    // the Ember form, and the prepped ticket is where the tech works next
+    await TabManager.activateTab(ticketTabId);
+    await TabManager.waitForTabComplete(ticketTabId);
+
     const result = await sendAutofillWithRetry(ticketTabId, requesterName, phoneNumber);
     if (!result.success) {
+      console.error('Ticket autofill failed:', result.error);
       return result.error || 'Ticket autofill failed for an unknown reason.';
     }
     sendWorkflowUpdate('New ticket prepped with caller details.');
     return null;
   } catch (error) {
+    console.error('Ticket autofill failed:', error);
     return formatErrorWithStack(error, true);
   }
 }
@@ -258,7 +281,7 @@ async function sendAutofillWithRetry(
   let lastError: unknown;
   for (let attempt = 0; attempt < AUTOFILL_RETRY.attempts; attempt++) {
     if (attempt > 0) {
-      await new Promise<void>((resolve) => setTimeout(resolve, AUTOFILL_RETRY.delayMs));
+      await delay(AUTOFILL_RETRY.delayMs);
     }
     try {
       return await MessageService.autofillTicket(tabId, requesterName, phoneNumber);
@@ -267,6 +290,13 @@ async function sendAutofillWithRetry(
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Promise-based delay helper
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 /**

--- a/src/scrapers/ticket-form-filler.ts
+++ b/src/scrapers/ticket-form-filler.ts
@@ -4,6 +4,13 @@ import { waitFor, dispatchMouseSequence } from '../utils/dom-utils';
 import { formatErrorWithStack } from '../utils/error-handler';
 
 /**
+ * Stage logging so the ticket tab's DevTools console shows autofill progress
+ */
+function log(message: string): void {
+  console.log(`[SD-Bot] ${message}`);
+}
+
+/**
  * Removes Froala's zero-width marker characters and trims whitespace
  */
 function cleanText(text: string | null | undefined): string {
@@ -51,15 +58,18 @@ async function applyTemplate(): Promise<HTMLElement> {
   // Template may already be applied (e.g. workflow re-run against the same tab)
   const alreadyPopulated = getPopulatedEditor();
   if (alreadyPopulated) {
+    log('Template content already present; skipping dropdown selection');
     return alreadyPopulated;
   }
 
+  log('Waiting for template dropdown trigger...');
   const trigger = await waitFor(
     () => document.querySelector<HTMLElement>(FRESHSERVICE_TICKET_SELECTORS.templateTrigger),
     TIMEOUTS.ticketFormLoad,
     'template dropdown trigger'
   );
 
+  log('Trigger found; opening dropdown');
   dispatchMouseSequence(trigger);
 
   let option: HTMLElement;
@@ -72,6 +82,13 @@ async function applyTemplate(): Promise<HTMLElement> {
   } catch {
     // Fallback: some power-select configurations toggle from the inline search
     // input inside the trigger rather than the trigger itself
+    const optionCount = document.querySelectorAll(
+      FRESHSERVICE_TICKET_SELECTORS.templateOption
+    ).length;
+    log(
+      `Dropdown did not show "${TICKET_TEMPLATE.name}" after trigger click ` +
+        `(${optionCount} option(s) visible); retrying via inline search input`
+    );
     const searchInput = trigger.querySelector<HTMLElement>(
       FRESHSERVICE_TICKET_SELECTORS.templateSearchInput
     );
@@ -86,8 +103,10 @@ async function applyTemplate(): Promise<HTMLElement> {
     );
   }
 
+  log(`Selecting "${TICKET_TEMPLATE.name}" option`);
   dispatchMouseSequence(option);
 
+  log('Waiting for template content to populate the editor...');
   return waitFor(
     getPopulatedEditor,
     TIMEOUTS.templateApply,
@@ -161,17 +180,21 @@ export async function autofillNewTicket(
   phoneNumber: string
 ): Promise<TicketAutofillResult> {
   try {
+    log(`Autofill started (requester: "${requesterName || '(blank)'}", phone: ${phoneNumber})`);
     const editor = await applyTemplate();
     rewriteDescription(editor, {
       [TICKET_TEMPLATE.tmNameLabel]: requesterName,
       [TICKET_TEMPLATE.phoneLabel]: phoneNumber,
       [TICKET_TEMPLATE.laptopLabel]: '',
     });
+    log('Description rewritten; autofill complete');
     return { success: true };
   } catch (error) {
+    const message = `Error autofilling new ticket: ${formatErrorWithStack(error, true)}`;
+    console.error(`[SD-Bot] ${message}`);
     return {
       success: false,
-      error: `Error autofilling new ticket: ${formatErrorWithStack(error, true)}`,
+      error: message,
     };
   }
 }

--- a/src/services/tab-manager.ts
+++ b/src/services/tab-manager.ts
@@ -106,5 +106,42 @@ export class TabManager {
   static async createTab(url: string, active: boolean = false): Promise<chrome.tabs.Tab> {
     return chrome.tabs.create({ url, active });
   }
+
+  /**
+   * Bring an existing tab to the foreground, including focusing its window
+   * Hidden tabs are deprioritized by Chrome (requestAnimationFrame never fires,
+   * timers are throttled), which can keep SPA pages from rendering or updating,
+   * and a tab in a buried window stays hidden even when it is the active tab
+   * @param tabId - The tab to activate
+   */
+  static async activateTab(tabId: number): Promise<void> {
+    const tab = await chrome.tabs.update(tabId, { active: true });
+    if (tab?.windowId !== undefined) {
+      await chrome.windows.update(tab.windowId, { focused: true });
+    }
+  }
+
+  /**
+   * Wait for an existing tab to reach status 'complete'
+   * Resolves (with a console warning) on timeout rather than rejecting, since a
+   * slow tab may still become usable moments later
+   * @param tabId - The tab to wait for
+   * @param timeout - Maximum time to wait in milliseconds (default: TIMEOUTS.tabLoad)
+   */
+  static async waitForTabComplete(tabId: number, timeout: number = TIMEOUTS.tabLoad): Promise<void> {
+    const deadline = Date.now() + timeout;
+
+    for (;;) {
+      const tab = await chrome.tabs.get(tabId);
+      if (tab.status === 'complete') {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        console.warn(`Tab ${tabId} not complete after ${timeout}ms. Proceeding anyway.`);
+        return;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    }
+  }
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -73,6 +73,13 @@ export const AUTOFILL_RETRY = {
   delayMs: 1000,
 } as const;
 
+// Retry configuration for extracting the calling number from MAX
+// (the call UI may need a moment to render after the window is brought forward)
+export const CALLING_NUMBER_RETRY = {
+  attempts: 8,
+  delayMs: 500,
+} as const;
+
 // Storage keys
 export const STORAGE_KEYS = {
   currentRequester: 'currentRequester',


### PR DESCRIPTION
Chrome deprioritizes hidden tabs and buried windows: requestAnimationFrame never fires and timers are throttled, so SPA pages may never render. This broke both ends of the workflow in the field:

- The new ticket tab (opened in the background) could stall before rendering the form, so the autofill timed out. The ticket tab is now activated and awaited (TabManager.activateTab + waitForTabComplete) before the autofill message is sent — it is also where the tech works next.
- The MAX agent window often sits buried when a call comes in, preventing calling number extraction. The MAX tab is now activated (including window focus) at workflow start, and extraction retries briefly while the call UI renders.

Also adds [SD-Bot] stage logging in the ticket form filler so the ticket tab's console shows exactly where autofill stalls, plus error logging in the background worker. Verified end-to-end by loading the built extension into Chromium against fixture pages built from dom-captures/ (full workflow: extraction -> search -> template selection -> description rewrite).


Claude-Session: https://claude.ai/code/session_01AZJKckVuk3YLaehdCSd866