### PR TITLE
Add build stamp and failure diagnostics for field-debugging autofill

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1318,7 +1318,13 @@ const element =
 
 ## Version History
 
-**Current Version**: 1.6.1
+**Current Version**: 1.6.2
+
+**Recent Changes (1.6.2)**:
+- Build timestamp (`__BUILD_INFO__`, injected by webpack DefinePlugin) shown in the sidepanel footer and logged by the FreshService content script on load — makes a stale `dist/` build immediately visible
+- Autofill failures now include a page-state snapshot (trigger/editor found, option count, title, URL) in the reported error
+- "Receiving end does not exist" autofill errors now include the ticket tab's status/discarded/url
+- New ticket form render wait raised from 15s to 30s
 
 **Recent Changes (1.6.1)**:
 - MAX tab is now activated (tab + window focus) before number extraction, with retries while the call UI renders — fixes extraction failing when the MAX window is buried behind others

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SD Bot",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Bot for automating various service desk functions",
   "icons": {
     "128": "dist/images/icon-128.png"

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -289,7 +289,17 @@ async function sendAutofillWithRetry(
       lastError = error;
     }
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+
+  // Include the ticket tab's state so "Receiving end does not exist" errors
+  // show whether the tab ever loaded (or was discarded) when retries ran out
+  let tabInfo = '';
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    tabInfo = ` (ticket tab: status=${tab.status}, discarded=${tab.discarded}, url=${tab.url || 'n/a'})`;
+  } catch {
+    tabInfo = ' (ticket tab no longer exists)';
+  }
+  throw new Error(`${formatErrorWithStack(lastError, true)}${tabInfo}`);
 }
 
 /**

--- a/src/content/freshservice.ts
+++ b/src/content/freshservice.ts
@@ -8,6 +8,10 @@ import { scrapeSearchResults } from '../scrapers/freshservice-scraper';
 import { autofillNewTicket } from '../scrapers/ticket-form-filler';
 import { createContentMessageHandler } from '../utils/content-message-handler';
 
+// Always log on load so any FreshService tab's console proves which build is
+// running and that the content script was injected at all
+console.log(`[SD-Bot] FreshService content script loaded (build ${__BUILD_INFO__}) on ${location.href}`);
+
 // Listen for messages from background script
 chrome.runtime.onMessage.addListener(
   createContentMessageHandler<ScrapeSearchResultsMessage, SearchResultsResultMessage>(

--- a/src/scrapers/ticket-form-filler.ts
+++ b/src/scrapers/ticket-form-filler.ts
@@ -164,6 +164,27 @@ function rewriteDescription(editor: HTMLElement, values: Readonly<Record<string,
 }
 
 /**
+ * Snapshot of the page state for failure diagnostics, so error reports show
+ * what the page actually looked like (e.g. form not rendered, a picker/dialog
+ * in the way, or selectors no longer matching)
+ */
+function buildDiagnostics(): string {
+  const trigger = document.querySelector(FRESHSERVICE_TICKET_SELECTORS.templateTrigger);
+  const anyTriggerCount = document.querySelectorAll('.ember-power-select-trigger').length;
+  const editor = getDescriptionEditor();
+  const optionCount = document.querySelectorAll(FRESHSERVICE_TICKET_SELECTORS.templateOption).length;
+  return [
+    `url=${location.pathname}`,
+    `title="${document.title}"`,
+    `templateTrigger=${trigger ? 'found' : 'MISSING'}`,
+    `powerSelectTriggersOnPage=${anyTriggerCount}`,
+    `descriptionEditor=${editor ? 'found' : 'MISSING'}`,
+    `visibleOptions=${optionCount}`,
+    `docHidden=${document.hidden}`,
+  ].join(', ');
+}
+
+/**
  * Applies the Standard Ticket template to the new ticket form and rewrites the
  * description down to the keep lines with caller details filled in:
  *
@@ -190,7 +211,9 @@ export async function autofillNewTicket(
     log('Description rewritten; autofill complete');
     return { success: true };
   } catch (error) {
-    const message = `Error autofilling new ticket: ${formatErrorWithStack(error, true)}`;
+    const message =
+      `Error autofilling new ticket: ${formatErrorWithStack(error, true)} | ` +
+      `Page state: ${buildDiagnostics()}`;
     console.error(`[SD-Bot] ${message}`);
     return {
       success: false,

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -32,6 +32,11 @@
       border-left: 4px solid #dc3545;
       color: #721c24;
     }
+    #build-info {
+      margin-top: 16px;
+      font-size: 11px;
+      color: #999;
+    }
   </style>
 </head>
 <body>
@@ -42,7 +47,9 @@
   </div>
   
   <div id="result"></div>
-  
+
+  <div id="build-info"></div>
+
   <script src="../sidepanel.js"></script>
 </body>
 </html>

--- a/src/sidepanel/sidepanel.ts
+++ b/src/sidepanel/sidepanel.ts
@@ -12,6 +12,7 @@ const resultDiv = document.getElementById('result');
 const requesterNameSpan = document.getElementById('requester-name');
 const phoneNumberSpan = document.getElementById('phone-number');
 const laptopSerialSpan = document.getElementById('laptop-serial');
+const buildInfoDiv = document.getElementById('build-info');
 
 /**
  * Initialize the sidepanel
@@ -30,6 +31,11 @@ function init(): void {
   resultDiv.className = '';
   if (phoneNumberSpan) phoneNumberSpan.textContent = '';
   if (requesterNameSpan) requesterNameSpan.textContent = '';
+
+  // Show version + build stamp so a stale dist/ build is immediately visible
+  if (buildInfoDiv) {
+    buildInfoDiv.textContent = `SD Bot v${chrome.runtime.getManifest().version} — built ${__BUILD_INFO__}`;
+  }
 }
 
 /**

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Global constants injected at build time by webpack DefinePlugin
+ * (see webpack.config.ts)
+ */
+
+/** Build timestamp, e.g. "2026-07-15 18:04 UTC" */
+declare const __BUILD_INFO__: string;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -60,7 +60,7 @@ export const TICKET_TEMPLATE = {
 export const TIMEOUTS = {
   tabLoad: 10000, // 10 seconds for tab to load
   contentRender: 500, // 500ms additional delay for content rendering
-  ticketFormLoad: 15000, // new ticket form (Ember SPA) render wait
+  ticketFormLoad: 30000, // new ticket form (Ember SPA) render wait
   dropdownOpen: 3000, // first wait for options after opening the template dropdown
   templateApply: 10000, // wait for template content to populate the editor
   domPoll: 200, // polling interval for DOM waits

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -40,6 +40,13 @@ const config = (env: unknown, argv: { mode?: string }): webpack.Configuration =>
     },
     
     plugins: [
+      // Bake a build timestamp into the compiled JS so a stale dist/ is
+      // immediately visible in the sidepanel and console logs
+      new webpack.DefinePlugin({
+        __BUILD_INFO__: JSON.stringify(
+          `${new Date().toISOString().replace('T', ' ').slice(0, 16)} UTC`
+        ),
+      }),
       new CopyWebpackPlugin({
         patterns: [
           { from: 'manifest.json', to: 'manifest.json' },


### PR DESCRIPTION
The autofill fix shipped in 1.6.1 reportedly changed nothing in the field, which is only consistent with either a stale dist/ build still running or a failure the current reporting doesn't surface clearly. Make both cases self-evident on the next run:

- Webpack now injects __BUILD_INFO__ (build timestamp); the sidepanel footer shows 'SD Bot v<version> — built <timestamp>' so a stale build is obvious, and the FreshService content script logs the build + URL on every page load
- Autofill failures append a page-state snapshot (template trigger/editor found or missing, power-select trigger count, visible option count, title, URL, visibility) to the error shown in the sidepanel
- Exhausted autofill message retries now report the ticket tab's status/discarded/url alongside the messaging error
- New ticket form render wait raised 15s -> 30s for slower loads


Claude-Session: https://claude.ai/code/session_01AZJKckVuk3YLaehdCSd866